### PR TITLE
[#25] build: rework healthchecks, adding bootstrapping phase

### DIFF
--- a/bin/docker-healthcheck-coord
+++ b/bin/docker-healthcheck-coord
@@ -1,39 +1,28 @@
 #!/bin/sh -eu
 
-psql \
-    -h "${PG_HOST}" \
-    -p "${PG_PORT}" \
-    -tc "SELECT 1 FROM pg_roles WHERE rolname = '${PG_USER_HEALTHCHECK}'" |
-        grep -q 1 ||
-        createuser "${PG_USER_HEALTHCHECK}"
+bootstrapped=.bootstrapped
 
-psql \
-    -h "${PG_HOST}" \
-    -p "${PG_PORT}" \
-    -tc "SELECT 1 FROM pg_database WHERE datname = '${PG_USER_HEALTHCHECK}'" |
-        grep -q 1 ||
-        createdb "${PG_USER_HEALTHCHECK}"
+if [ ! -f "$bootstrapped" ]; then
+    createuser "${PG_USER_HEALTHCHECK}" || true
+    
+    createdb "${PG_USER_HEALTHCHECK}" || true
+    
+    psql \
+        -h "${PG_HOST}" \
+        -p "${PG_PORT}" \
+        -U "${PG_USER_HEALTHCHECK}" \
+        -d "${PG_USER_HEALTHCHECK}" \
+        -c 'CREATE TABLE ping (t_ins timestamptz NOT NULL DEFAULT now())' ||
+    true
+fi
 
-psql \
-    -h "${PG_HOST}" \
-    -p "${PG_PORT}" \
-    -U "${PG_USER_HEALTHCHECK}" \
-    -tc "SELECT * FROM pg_tables WHERE
-        (schemaname, tablename, tableowner) =
-            ('public', 'ping', '${PG_USER_HEALTHCHECK}')" |
-        wc -l |
-        grep -q 2 ||
-        psql \
-            -h "${PG_HOST}" \
-            -p "${PG_PORT}" \
-            -U "${PG_USER_HEALTHCHECK}" \
-            -d "${PG_USER_HEALTHCHECK}" \
-            -c 'CREATE TABLE ping (t_ins timestamptz NOT NULL DEFAULT now())'
-
-psql \
-    -h "${PG_HOST}" \
-    -p "${PG_PORT}" \
-    -U "${PG_USER_HEALTHCHECK}" \
-    -d "${PG_USER_HEALTHCHECK}" \
-    -c 'INSERT INTO ping VALUES (DEFAULT)' ||
-        false
+(
+    psql \
+        -h "${PG_HOST}" \
+        -p "${PG_PORT}" \
+        -U "${PG_USER_HEALTHCHECK}" \
+        -d "${PG_USER_HEALTHCHECK}" \
+        -c 'INSERT INTO ping VALUES (DEFAULT)' &&
+    touch "$bootstrapped"
+) ||
+[ ! -f "$bootstrapped" ]

--- a/bin/docker-healthcheck-data
+++ b/bin/docker-healthcheck-data
@@ -1,8 +1,13 @@
 #!/bin/sh -eu
 
-psql \
-    -h "${PG_HOST}" \
-    -p "${PG_PORT}" \
-    -U "${PG_USER_HEALTHCHECK}" \
-    -c 'SELECT version()' ||
-        false
+bootstrapped=.bootstrapped
+
+(
+    psql \
+        -h "${PG_HOST}" \
+        -p "${PG_PORT}" \
+        -U "${PG_USER_HEALTHCHECK}" \
+        -c 'SELECT version()' &&
+    touch "$bootstrapped"
+) ||
+[ ! -f "$bootstrapped" ]

--- a/bin/init-eg
+++ b/bin/init-eg
@@ -37,8 +37,6 @@ startup
 
 for node in "${nodes[@]}"
 do
-    docker-compose start "$node"
-    
     cmd "$node" "CREATE NODE coord_1 WITH (TYPE = 'coordinator', HOST = 'db_coord_1', PORT = 5432);"
     cmd "$node" "CREATE NODE coord_2 WITH (TYPE = 'coordinator', HOST = 'db_coord_2', PORT = 5432);"
     cmd "$node" "CREATE NODE data_1  WITH (TYPE = 'datanode',    HOST = 'db_data_1',  PORT = 5432);"
@@ -49,7 +47,4 @@ do
     cmd "$node" "ALTER  NODE data_2  WITH (TYPE = 'datanode',    HOST = 'db_data_2',  PORT = 5432);"
     cmd "$node" "SELECT pgxc_pool_reload();"
     cmd "$node" "SELECT * FROM pgxc_node;"
-    
-    docker-compose stop "$node"
-    docker-compose start "$node"
 done

--- a/bin/init-eg-swarm
+++ b/bin/init-eg-swarm
@@ -3,7 +3,6 @@
 stack=$1
 
 nodes=(db_coord_1 db_coord_2 db_data_1 db_data_2)
-PG_USER_HEALTHCHECK=_healthcheck
 #-------------------------------------------------------------------------------
 function log() {
     local msg="$*"
@@ -42,13 +41,6 @@ function get_container() {
     echo "${stack}_${node}.1.${id}"
 }
 
-function get_healthcheck() {
-    local node=$1
-    
-    docker service inspect "${stack}_${node}" \
-        -f '{{ index .Spec.TaskTemplate.ContainerSpec.Healthcheck.Test 1 }}'
-}
-
 trap shutdown EXIT
 #-------------------------------------------------------------------------------
 startup
@@ -67,26 +59,3 @@ for node in "${nodes[@]}" ; do
     cmd "$ctnr" "SELECT pgxc_pool_reload();"
     cmd "$ctnr" "SELECT * FROM pgxc_node;"
 done
-
-for node in "${nodes[@]}" ; do
-    healthcheck=$(get_healthcheck "$node")
-    
-    docker service update "${stack}_${node}" \
-        --health-cmd "$healthcheck || true"
-done
-
-while true ; do
-    log "WAITING"
-    
-    for node in "${nodes[@]}" ; do
-        ctnr=$(get_container "$node")
-        
-        srv "$ctnr" psql -tc "SELECT 1 FROM pg_database
-            WHERE datname = '${PG_USER_HEALTHCHECK}'" |
-            grep -q 1 && break 2
-    done
-    
-    sleep 1
-done
-
-log "REDEPLOY stack now !" # to reset healthchecks, and reboot


### PR DESCRIPTION
Docker Swarm usage complicates healthchecks, since the containers are
unroutable until healthchecks pass, but for healthchecks to pass, the
cluster has to be not only routing correctly, but initialised.

The Swarm example init script, `bin/init-eg-swarm`, overcame this by
overriding the healthchecks at the service level, allowing them to pass.
Then, the cluster was expected to be redeployed, in order for the
healthchecks to pass. This, however, is not only rather unpleasant, but
still doesn't solve issues in all cases, or indeed when using other
schedulers or approaches.

Rework healthchecks, adding a bootstrapping phase. Now, when containers
come up, healthchecks will pass trivially, even if the cluster hasn't
been initted. However, on every Coord healthcheck, an attempt will be
made to create the user, database, and table necessary for the proper
healthcheck to pass. If this fails, however, it won't cause the
healthcheck to fail. Then, whenever the healthcheck passes for the first
time properly, necessarily after init, the bootstrapping phase is
complete, and all future Coord and Data healthchecks will check
properly.

This also has the side-effect of optimising the healthcheck to be
lighter, and allows also for the `bin/init-eg-swarm` script to avoid the
unpleasant service healthcheck overrides. This also means that a
redeploy is no longer needed.

Also optimise `bin/init-eg` (non-Swarm) example init script, to not
restart the containers, since this is not necessary.