### PR TITLE
[#29] build: improve GTM healthcheck to not throw error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update && \
         daemontools \
         flex \
         libreadline-dev \
-        netcat \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
@@ -29,11 +28,15 @@ USER ${PG_USER}
 WORKDIR ${PG_HOME}/lib/postgres-xl
 
 RUN ./configure --prefix ${PG_LIB} && \
+    make && \
+    cd contrib/pgxc_monitor && \
     make
 #-------------------------------------------------------------------------------
 USER root
 
-RUN make install
+RUN make install && \
+    cd contrib/pgxc_monitor && \
+    make install
 #-------------------------------------------------------------------------------
 USER ${PG_USER}
 

--- a/bin/docker-healthcheck-gtm
+++ b/bin/docker-healthcheck-gtm
@@ -1,3 +1,15 @@
-#!/bin/sh -eu
+#!/bin/bash -eu
 
-nc -z "${PG_HOST}" "${PG_PORT}"
+# This is a magic string, reverse-engineered by using tcpdump on the GTM to see
+# what is a minimal valid startup packet from a Datanode, and substituting bytes
+# into it with reference to the Postgres-XL source. Previously, although the
+# healthcheck succeeded and everything seemed to work, the GTM logged error
+# 
+#     Expecting a startup message, but received �
+# 
+# SEE: https://github.com/pavouk-0/postgres-xl-docker/issues/29
+# SEE: https://github.com/pavouk-0/postgres-xl-docker/issues/15
+# SEE: Postgres-XL source: src/gtm/main/main.c
+magic_string="\x41\x00\x00\x00\x50\x5f\x68\x65\x61\x6c\x74\x68\x63\x68\x65\x63\x6b\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+
+printf "%b" "$magic_string" | nc -w 1 "${PG_HOST}" "${PG_PORT}" || false

--- a/bin/docker-healthcheck-gtm
+++ b/bin/docker-healthcheck-gtm
@@ -1,3 +1,3 @@
 #!/bin/sh -eu
 
-nc -z "${PG_HOST}" "${PG_PORT}"
+pgxc_monitor -Z gtm -h "${PG_HOST}" -p "${PG_PORT}"

--- a/bin/docker-healthcheck-gtm
+++ b/bin/docker-healthcheck-gtm
@@ -1,15 +1,3 @@
-#!/bin/bash -eu
+#!/bin/sh -eu
 
-# This is a magic string, reverse-engineered by using tcpdump on the GTM to see
-# what is a minimal valid startup packet from a Datanode, and substituting bytes
-# into it with reference to the Postgres-XL source. Previously, although the
-# healthcheck succeeded and everything seemed to work, the GTM logged error
-# 
-#     Expecting a startup message, but received �
-# 
-# SEE: https://github.com/pavouk-0/postgres-xl-docker/issues/29
-# SEE: https://github.com/pavouk-0/postgres-xl-docker/issues/15
-# SEE: Postgres-XL source: src/gtm/main/main.c
-magic_string="\x41\x00\x00\x00\x50\x5f\x68\x65\x61\x6c\x74\x68\x63\x68\x65\x63\x6b\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
-
-printf "%b" "$magic_string" | nc -w 1 "${PG_HOST}" "${PG_PORT}" || false
+nc -z "${PG_HOST}" "${PG_PORT}"

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -7,8 +7,7 @@ ARG PG_USER=postgres
 #-------------------------------------------------------------------------------
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        libreadline-dev \
-        netcat && \
+        libreadline-dev && \
     rm -rf /var/lib/apt/lists/*
 
 RUN useradd ${PG_USER} -d ${PG_HOME} && \


### PR DESCRIPTION
Previously, although the healthcheck succeeded and everything seemed to
work, the GTM logged error

    Expecting a startup message, but received �

Fix by reverse-engineering the minimal startup packet for the GTM, using
tcpdump and nikolaka/netshoot image tcpdump using a command like

    docker run -it --rm --net container:e0f3eec77071 nicolaka/netshoot \
        tcpdump -X -i lo