### PR TITLE
[#37] healthcheck-coord: hack jammy healthchecks, with random sleep

### DIFF
--- a/bin/docker-healthcheck-coord
+++ b/bin/docker-healthcheck-coord
@@ -1,8 +1,13 @@
-#!/bin/sh -eu
+#!/bin/bash -eu
 
 bootstrapped=.bootstrapped
-
+sleep_int_max=30
+#-------------------------------------------------------------------------------
 if [ ! -f "$bootstrapped" ]; then
+    sleep_int=$(((RANDOM % sleep_int_max) + 1))
+    echo "Sleeping to avoid race-condition (!) [$sleep_int s]"
+    sleep "$sleep_int"
+    
     createuser \
          -h "${PG_HOST}" \
          -p "${PG_PORT}" \


### PR DESCRIPTION
There appears to be a race-condition with calling `createdb` from 2
Coordinators at once. This is reproducible multiple times, on both the
Docker Hub images and building this from source. Since the healthchecks
were reworked, sometimes `createdb` freezes, and bootstrapping never
completes. I've since found that killing the `createdb` process allows
the bootstrapping to complete.

Adding a random sleep also appears to avoid the race-condition, and
allow the bootstrapping to complete (!). If this is confirmed, then this
is surely a bug in upstream Postgres-XL; I don't see anything in the
packaging itself which could lead to this. Let's try to get some
confirmations, and report it upstream, if so. At least with the
Postgres-XL Docker images, then reproducing things and tearing down and
rebuilding clusters is actually pretty straightforward.

Note that this does not appear to affect `createuser`, for some reason.